### PR TITLE
Bump version: 2.1.4 → 2.1.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.4
+current_version = 2.1.5
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[\+a-z]+)\.(?P<build>\d+))?

--- a/Gene_Drive/__version__.py
+++ b/Gene_Drive/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "2.1.4.dev.0"
+__version__ = "2.1.5.dev.0"

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     python_requires='>=3.9',
     test_suite='tests',
     extras_require=extras,
-    version='2.1.4.dev.0',
+    version='2.1.5.dev.0',
 
 )


### PR DESCRIPTION
I just realized that there is this condition
[Bump version: needs to be in commit message](https://github.com/InstituteforDiseaseModeling/dash-gene-drive/blob/757cc8e13217f66b354c972202f959ae7fb435eb/.github/workflows/staging-build-package.yml#L31)